### PR TITLE
Add option to access 'get_role'

### DIFF
--- a/backend/shop/permissions.py
+++ b/backend/shop/permissions.py
@@ -1,0 +1,6 @@
+def can_view_groups(user):
+    return (
+        user.is_superuser
+        or user.has_perm("auth.change_group")
+        or user.has_perm("auth.view_group")
+    )

--- a/backend/shop/tests/test_views.py
+++ b/backend/shop/tests/test_views.py
@@ -360,3 +360,40 @@ class TestGroup(APITestCase):
 
         no_of_groups_after = Group.objects.all().count()
         self.assertEqual(no_of_groups_before, no_of_groups_after)
+
+
+class TestRoleAccessWithDifferentPermissions(APITestCase):
+    def setUp(self):
+        self.user = CoreUserFactory()
+        self.url = reverse("role_get")
+
+    def test_view_permissions_success_access_with_change_permission(self):
+        permission_change_role = Permission.objects.get(codename="change_group")
+        self.user.user_permissions.add(permission_change_role)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_permissions_success_access_with_view_permission(self):
+        permission_view_role = Permission.objects.get(codename="view_group")
+        self.user.user_permissions.add(permission_view_role)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_permissions_success_superuser(self):
+        self.user.is_superuser = True
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_permissions_failure_no_access_with_wrong_permission(self):
+        permission_view_role = Permission.objects.get(codename="change_shopprofile")
+        self.user.user_permissions.add(permission_view_role)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import IntegrityError
 from math import ceil
 from django.core.paginator import Paginator
@@ -17,8 +17,10 @@ from .serializers import (
 )
 from django.contrib.auth.decorators import permission_required, login_required
 
+
 from shop.models import ShopProfile, Role
 from core.models import CoreUser
+from .permissions import can_view_groups
 
 
 @api_view(["GET"])
@@ -251,8 +253,9 @@ def permission_get(request):
 
 @api_view(["GET"])
 @login_required()
-@permission_required("shop.view_role", raise_exception=True)
 def role_get(request):
+    if not can_view_groups(request.user):
+        raise PermissionDenied("You don't have permission to view groups.")
     roles = Group.objects.all()
     serializer = GroupSerializer(roles, many=True)
     return Response(serializer.data)


### PR DESCRIPTION
In view 'get_role' was added checking if the user has permission to access.

[What?]
Adding an option, that user with 'view_' and 'change_' permission can access to 'role_get' view.

[Why?]
If the user has only permission 'edit_', it is necessary to access the 'role_get'.

[How?]
I created a function inside `permissions.py` file, which checks if the user has 'view_' or 'change_' permission.

[Testing?]
- test if the user has only 'view_' permission
- test if the user has only 'change_' permission
- test if the user is the superuser
- test if the user has the wrong permission

[Anything_else?]
I didn't use `@user_passes_test()` decorator, because it return the 302 HTTP code (redirect to login). I think it is more correct to return 403 (forbidden - authentication makes no difference).