### PR TITLE
Handling errors on frontend

### DIFF
--- a/frontend/src/pages/dashboard/roles/Roles.test.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.test.tsx
@@ -13,8 +13,8 @@ const roles = [
     { name: "Manager" },
 ];
 
-describe("axios mocking test", () => {
-    test("should render loading followed by roles", async () => {
+describe("rendering roles", () => {
+    test("render roles, success, should render loaded roles", async () => {
         mock.onGet("/shop-api-v1/role").reply(200, roles);
 
         const wrapper = render(<Roles />);
@@ -25,6 +25,46 @@ describe("axios mocking test", () => {
                 const text = screen.getByText(role.name);
                 expect(text.textContent).toBeTruthy();
             });
+        });
+    });
+
+    test("render roles, success, no roles", async () => {
+        mock.onGet("/shop-api-v1/role").reply(200, []);
+
+        const wrapper = render(<Roles />);
+        expect(wrapper).toBeTruthy();
+
+        await waitFor(() => {
+            const no_roles_msg = screen.getByText(
+                /No roles available yet. Select 'Add role' to add one./i,
+            );
+            expect(no_roles_msg).toBeTruthy();
+        });
+    });
+
+    test("render roles, failure, not authenticated", async () => {
+        mock.onGet("/shop-api-v1/role").reply(401);
+
+        const wrapper = render(<Roles />);
+        expect(wrapper).toBeTruthy();
+
+        await waitFor(() => {
+            const no_roles_msg = screen.getByText(/You are not logged in.../i);
+            expect(no_roles_msg).toBeTruthy();
+        });
+    });
+
+    test("render roles, failure, no permissions", async () => {
+        mock.onGet("/shop-api-v1/role").reply(403);
+
+        const wrapper = render(<Roles />);
+        expect(wrapper).toBeTruthy();
+
+        await waitFor(() => {
+            const no_roles_msg = screen.getByText(
+                /You don't have permissions to see roles.../i,
+            );
+            expect(no_roles_msg).toBeTruthy();
         });
     });
 });

--- a/frontend/src/pages/dashboard/roles/Roles.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.tsx
@@ -33,6 +33,10 @@ const Roles = () => {
                 "\nMessage from server:",
                 err.response?.data,
             );
+            if (err.response.status == 401) {
+                setErrMsg("You are not logged in...");
+                return;
+            }
             if (err.response.status == 403) {
                 setErrMsg("You don't have permissions to see roles...");
                 return;


### PR DESCRIPTION
[What?]
Handling errors on getting `Roles` in frontend.

[Why?]
To indicate user, what went wrong and comunicate possible solutions.

[How?]
In frontend check response status, setting `errMsg` if status is not 200.

[Testing?]
- success, no roles
- failure, not authenticated
- failure, not permissions