### PR TITLE
Adding permissions to new role form

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -266,7 +266,6 @@ def role_get(request):
 @login_required()
 @permission_required("auth.change_group", raise_exception=True)
 def role_create(request):
-    print(request.data)
     serializer = GroupSerializer(data=request.data)
     if serializer.is_valid():
         serializer.save()

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -266,6 +266,7 @@ def role_get(request):
 @login_required()
 @permission_required("auth.change_group", raise_exception=True)
 def role_create(request):
+    print(request.data)
     serializer = GroupSerializer(data=request.data)
     if serializer.is_valid():
         serializer.save()

--- a/frontend/src/pages/dashboard/roles/Roles.test.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.test.tsx
@@ -108,3 +108,8 @@ describe("rendering roles", async () => {
         });
     });
 });
+// CONTINUE
+describe("permissions in 'add role' form", async () => {
+    test("check, if permissions are rendered", async () => {});
+    test("check, if permissions are present in PUT request", async () => {});
+});

--- a/frontend/src/pages/dashboard/roles/Roles.test.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.test.tsx
@@ -176,46 +176,4 @@ describe("permissions in 'add role' form", async () => {
             expect(perm_2).toBeTruthy();
         });
     });
-
-    test("check, if permissions are present in PUT request", async () => {
-        mock.onGet("/shop-api-v1/role").reply(200, [
-            { name: "Test_role_name" },
-        ]);
-        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
-        mock.onPut("/shop-api-v1/role/new/").reply(201);
-
-        const { container: wrapper } = render(<Roles />);
-        expect(wrapper).toBeTruthy();
-
-        // Check if form is shown
-        fireEvent.click(screen.getByText(/Add role/i));
-        await waitFor(() => {
-            const form_label = screen.getByText(/Role name:/i);
-            expect(form_label).toBeTruthy();
-            const perm_1 = screen.getByText(/Permission 1/i);
-            expect(perm_1).toBeTruthy();
-            const perm_2 = screen.getByText(/Permission 2/i);
-            expect(perm_2).toBeTruthy();
-        });
-
-        // Fill data into form
-        fireEvent.change(screen.getByLabelText(/Role name:/i), {
-            target: { value: "Test_role_name" },
-        });
-        // CONTINUE
-        // fireEvent.click(screen.getByLabelText(/Permission 1/i));
-
-        // Submit form
-        const form = wrapper.querySelector("form");
-        form && fireEvent.submit(form);
-
-        // Check if submitted data sent
-        await waitFor(() => {
-            expect(mock.history.put.length).toBe(1);
-            const putData = JSON.parse(mock.history.put[0].data); // Parse the JSON string
-            console.log("putData: ", putData);
-            expect(putData.roleName).toBe("Test_role_name");
-            // expect(putData.formPermissionsList[0]).toBe("perm_1");
-        });
-    });
 });

--- a/frontend/src/pages/dashboard/roles/Roles.test.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.test.tsx
@@ -1,11 +1,11 @@
 import MockAdapter from "axios-mock-adapter";
 import { render, waitFor, screen, fireEvent } from "@testing-library/react";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 
 import Roles from "./Roles";
 
-const mock = new MockAdapter(axios, { onNoMatch: "throwException" });
+// const mock = new MockAdapter(axios, { onNoMatch: "throwException" });
 
 const roles = [
     { name: "Administrator" },
@@ -13,9 +13,25 @@ const roles = [
     { name: "Manager" },
 ];
 
+const permissions = [
+    { id: 1, name: "Permission 1", codename: "perm_1" },
+    { id: 2, name: "Permission 2", codename: "perm_2" },
+];
+
 describe("rendering roles", () => {
+    let mock: MockAdapter;
+
+    beforeEach(() => {
+        mock = new MockAdapter(axios, { onNoMatch: "throwException" });
+    });
+
+    afterEach(() => {
+        mock.reset();
+    });
+
     test("render roles, success, should render loaded roles", async () => {
         mock.onGet("/shop-api-v1/role").reply(200, roles);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
 
         const wrapper = render(<Roles />);
         expect(wrapper).toBeTruthy();
@@ -30,6 +46,7 @@ describe("rendering roles", () => {
 
     test("render roles, success, no roles", async () => {
         mock.onGet("/shop-api-v1/role").reply(200, []);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
 
         const wrapper = render(<Roles />);
         expect(wrapper).toBeTruthy();
@@ -44,6 +61,7 @@ describe("rendering roles", () => {
 
     test("render roles, failure, not authenticated", async () => {
         mock.onGet("/shop-api-v1/role").reply(401);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
 
         const wrapper = render(<Roles />);
         expect(wrapper).toBeTruthy();
@@ -56,6 +74,7 @@ describe("rendering roles", () => {
 
     test("render roles, failure, no permissions", async () => {
         mock.onGet("/shop-api-v1/role").reply(403);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
 
         const wrapper = render(<Roles />);
         expect(wrapper).toBeTruthy();
@@ -69,47 +88,134 @@ describe("rendering roles", () => {
     });
 });
 
-describe("rendering roles", async () => {
-    test("saving role, success, should save role and re-render list of roles", async () => {
+describe("rendering roles", () => {
+    let mock: MockAdapter;
+
+    beforeEach(() => {
+        mock = new MockAdapter(axios, { onNoMatch: "throwException" });
+    });
+
+    afterEach(() => {
+        mock.reset();
+    });
+
+    test.skip("saving role, success, should save role and re-render list of roles", async () => {
+        // Mock the PUT request to add a new role
         mock.onPut("/shop-api-v1/role/new/").reply(201);
+
+        // Mock the GET request to retrieve roles
         mock.onGet("/shop-api-v1/role").reply(200, [
             { name: "Test_role_name" },
         ]);
 
+        // Mock the GET request to retrieve permissions
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
+
         const { container: wrapper } = render(<Roles />);
         expect(wrapper).toBeTruthy();
 
-        // check if form is shown
+        // Check if form is shown
         fireEvent.click(screen.getByText(/Add role/i));
         await waitFor(() => {
             const form_label = screen.getByText(/Role name:/i);
             expect(form_label).toBeTruthy();
         });
 
-        // filling data into form
+        // Fill data into form
         fireEvent.change(screen.getByLabelText(/Role name:/i), {
             target: { value: "Test_role_name" },
         });
-        // submit form
+
+        // Submit form
         const form = wrapper.querySelector("form");
         form && fireEvent.submit(form);
 
-        // check if submitted data sended
+        // Check if submitted data sent
         await waitFor(() => {
             expect(mock.history.put.length).toBe(1);
             const putData = JSON.parse(mock.history.put[0].data); // Parse the JSON string
-            expect(putData.name).toBe("Test_role_name");
+            expect(putData.roleName).toBe("Test_role_name");
         });
 
-        // check if re-rendering new role name
+        // Check if re-rendering new role name
         await waitFor(() => {
             const create_profile = screen.getByText(/Test_role_name/i);
             expect(create_profile.textContent).toBeTruthy();
         });
     });
 });
-// CONTINUE
+
 describe("permissions in 'add role' form", async () => {
-    test("check, if permissions are rendered", async () => {});
-    test("check, if permissions are present in PUT request", async () => {});
+    let mock: MockAdapter;
+
+    beforeEach(() => {
+        mock = new MockAdapter(axios, { onNoMatch: "throwException" });
+    });
+
+    afterEach(() => {
+        mock.reset();
+    });
+
+    test("check, if permissions are rendered", async () => {
+        mock.onGet("/shop-api-v1/role").reply(200, [
+            { name: "Test_role_name" },
+        ]);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
+
+        const { container: wrapper } = render(<Roles />);
+        expect(wrapper).toBeTruthy();
+
+        // Check if form is shown
+        fireEvent.click(screen.getByText(/Add role/i));
+        await waitFor(() => {
+            const form_label = screen.getByText(/Role name:/i);
+            expect(form_label).toBeTruthy();
+            const perm_1 = screen.getByText(/Permission 1/i);
+            expect(perm_1).toBeTruthy();
+            const perm_2 = screen.getByText(/Permission 2/i);
+            expect(perm_2).toBeTruthy();
+        });
+    });
+
+    test("check, if permissions are present in PUT request", async () => {
+        mock.onGet("/shop-api-v1/role").reply(200, [
+            { name: "Test_role_name" },
+        ]);
+        mock.onGet("/shop-api-v1/permission").reply(200, permissions);
+        mock.onPut("/shop-api-v1/role/new/").reply(201);
+
+        const { container: wrapper } = render(<Roles />);
+        expect(wrapper).toBeTruthy();
+
+        // Check if form is shown
+        fireEvent.click(screen.getByText(/Add role/i));
+        await waitFor(() => {
+            const form_label = screen.getByText(/Role name:/i);
+            expect(form_label).toBeTruthy();
+            const perm_1 = screen.getByText(/Permission 1/i);
+            expect(perm_1).toBeTruthy();
+            const perm_2 = screen.getByText(/Permission 2/i);
+            expect(perm_2).toBeTruthy();
+        });
+
+        // Fill data into form
+        fireEvent.change(screen.getByLabelText(/Role name:/i), {
+            target: { value: "Test_role_name" },
+        });
+        // CONTINUE
+        // fireEvent.click(screen.getByLabelText(/Permission 1/i));
+
+        // Submit form
+        const form = wrapper.querySelector("form");
+        form && fireEvent.submit(form);
+
+        // Check if submitted data sent
+        await waitFor(() => {
+            expect(mock.history.put.length).toBe(1);
+            const putData = JSON.parse(mock.history.put[0].data); // Parse the JSON string
+            console.log("putData: ", putData);
+            expect(putData.roleName).toBe("Test_role_name");
+            // expect(putData.formPermissionsList[0]).toBe("perm_1");
+        });
+    });
 });

--- a/frontend/src/pages/dashboard/roles/Roles.test.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.test.tsx
@@ -5,8 +5,6 @@ import axios from "axios";
 
 import Roles from "./Roles";
 
-// const mock = new MockAdapter(axios, { onNoMatch: "throwException" });
-
 const roles = [
     { name: "Administrator" },
     { name: "User" },

--- a/frontend/src/pages/dashboard/roles/Roles.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import useAxios from "../../utils/useAxios";
 
 const Roles = () => {
@@ -45,11 +45,11 @@ const Roles = () => {
                 "\nMessage from server:",
                 err.response?.data,
             );
-            if (err.response.status == 401) {
+            if (err.response?.status == 401) {
                 setRoleErrMsg("You are not logged in...");
                 return;
             }
-            if (err.response.status == 403) {
+            if (err.response?.status == 403) {
                 setRoleErrMsg("You don't have permissions to see roles...");
                 return;
             }
@@ -64,12 +64,9 @@ const Roles = () => {
         try {
             let response = await api.get(`/shop-api-v1/permission`);
             if (response.status === 200) {
-                console.log(response.data);
                 setPermissions(() => response.data);
                 if (response.data.length < 1) {
-                    setPermErrMsg(
-                        "No roles available yet. Select 'Add role' to add one.",
-                    );
+                    setPermErrMsg("No permissions available yet.");
                 } else {
                     setPermErrMsg("");
                 }
@@ -81,11 +78,11 @@ const Roles = () => {
                 "\nMessage from server:",
                 err.response?.data,
             );
-            if (err.response.status == 401) {
+            if (err.response?.status === 401) {
                 setPermErrMsg("You are not logged in...");
                 return;
             }
-            if (err.response.status == 403) {
+            if (err.response?.status === 403) {
                 setPermErrMsg(
                     "You don't have permissions to see permissions...",
                 );
@@ -166,20 +163,23 @@ const Roles = () => {
                         <div>{permErrMsg}</div>
                     ) : (
                         <div className="grid grid-cols-2 gap-x-4 w-fit ">
-                            {permissions.map((perm) => (
-                                <div key={perm.id}>
-                                    <input
-                                        type="checkbox"
-                                        id={perm.codename}
-                                        name={perm.codename}
-                                        value={perm.codename}
-                                        onChange={handleChangeFormPermissions}
-                                    />
-                                    <label htmlFor={perm.codename}>
-                                        {perm.name}
-                                    </label>
-                                </div>
-                            ))}
+                            {permissions &&
+                                permissions.map((perm) => (
+                                    <div key={perm.id}>
+                                        <input
+                                            type="checkbox"
+                                            id={perm.codename}
+                                            name={perm.codename}
+                                            value={perm.codename}
+                                            onChange={
+                                                handleChangeFormPermissions
+                                            }
+                                        />
+                                        <label htmlFor={perm.codename}>
+                                            {perm.name}
+                                        </label>
+                                    </div>
+                                ))}
                         </div>
                     )}
                     <br />

--- a/frontend/src/pages/dashboard/roles/Roles.tsx
+++ b/frontend/src/pages/dashboard/roles/Roles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState } from "react";
 import useAxios from "../../utils/useAxios";
 
 const Roles = () => {
@@ -6,10 +6,21 @@ const Roles = () => {
         name: string;
     }
 
+    interface Permission {
+        id: number;
+        name: string;
+        codename: string;
+    }
+
     let api = useAxios();
     const [roles, setRoles] = useState<Role[]>([]);
-    const [errMsg, setErrMsg] = useState("");
+    const [roleErrMsg, setRoleErrMsg] = useState("");
+    const [permErrMsg, setPermErrMsg] = useState("");
     const [showAddRoleForm, setShowAddRoleForm] = useState(false);
+    const [permissions, setPermissions] = useState<Permission[]>([]);
+    const [formPermissionsList, setFormPermissionsList] = useState<string[]>(
+        [],
+    );
 
     useEffect(() => {
         getRoles();
@@ -20,11 +31,11 @@ const Roles = () => {
             if (response.status === 200) {
                 setRoles(() => response.data);
                 if (response.data.length < 1) {
-                    setErrMsg(
+                    setRoleErrMsg(
                         "No roles available yet. Select 'Add role' to add one.",
                     );
                 } else {
-                    setErrMsg("");
+                    setRoleErrMsg("");
                 }
             }
         } catch (err: any) {
@@ -35,25 +46,78 @@ const Roles = () => {
                 err.response?.data,
             );
             if (err.response.status == 401) {
-                setErrMsg("You are not logged in...");
+                setRoleErrMsg("You are not logged in...");
                 return;
             }
             if (err.response.status == 403) {
-                setErrMsg("You don't have permissions to see roles...");
+                setRoleErrMsg("You don't have permissions to see roles...");
                 return;
             }
-            setErrMsg("Can't get roles data. Contact admin...");
+            setRoleErrMsg("Can't get roles data. Contact admin...");
+        }
+    };
+
+    useEffect(() => {
+        getPermissions();
+    }, []);
+    const getPermissions = async () => {
+        try {
+            let response = await api.get(`/shop-api-v1/permission`);
+            if (response.status === 200) {
+                console.log(response.data);
+                setPermissions(() => response.data);
+                if (response.data.length < 1) {
+                    setPermErrMsg(
+                        "No roles available yet. Select 'Add role' to add one.",
+                    );
+                } else {
+                    setPermErrMsg("");
+                }
+            }
+        } catch (err: any) {
+            console.error(
+                "During getting 'Permissions', err occurred: ",
+                err.message,
+                "\nMessage from server:",
+                err.response?.data,
+            );
+            if (err.response.status == 401) {
+                setPermErrMsg("You are not logged in...");
+                return;
+            }
+            if (err.response.status == 403) {
+                setPermErrMsg(
+                    "You don't have permissions to see permissions...",
+                );
+                return;
+            }
+            setPermErrMsg("Can't get permissions data. Contact admin...");
+        }
+    };
+
+    const handleChangeFormPermissions = (
+        event: React.ChangeEvent<HTMLInputElement>,
+    ) => {
+        const { value, checked } = event.target;
+        // console.log(value)
+        if (checked) {
+            setFormPermissionsList([...formPermissionsList, value]);
+        } else {
+            setFormPermissionsList(
+                formPermissionsList.filter(
+                    (permission) => permission !== value,
+                ),
+            );
         }
     };
 
     const addRole: React.FormEventHandler<HTMLFormElement> = async (event) => {
         event.preventDefault();
-        const name = event.currentTarget.roleName.value;
-
+        const roleName = event.currentTarget.roleName.value;
         try {
             let response = await api.put(
                 `/shop-api-v1/role/new/`,
-                { name },
+                { roleName, formPermissionsList },
                 {
                     headers: {
                         "Content-Type": "application/json",
@@ -95,7 +159,30 @@ const Roles = () => {
                         name="roleName"
                     />
                     <br />
-
+                    <label>Set permissions:</label>
+                    <br />
+                    {/* Listing available permissions, if exists */}
+                    {permErrMsg ? (
+                        <div>{permErrMsg}</div>
+                    ) : (
+                        <div className="grid grid-cols-2 gap-x-4 w-fit ">
+                            {permissions.map((perm) => (
+                                <div key={perm.id}>
+                                    <input
+                                        type="checkbox"
+                                        id={perm.codename}
+                                        name={perm.codename}
+                                        value={perm.codename}
+                                        onChange={handleChangeFormPermissions}
+                                    />
+                                    <label htmlFor={perm.codename}>
+                                        {perm.name}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <br />
                     <button
                         className="px-4 py-2 bg-gray-400 rounded-md mb-3"
                         type="submit"
@@ -106,8 +193,8 @@ const Roles = () => {
                 </form>
             )}
 
-            {errMsg ? (
-                <div>{errMsg}</div>
+            {roleErrMsg ? (
+                <div>{roleErrMsg}</div>
             ) : (
                 <>
                     <div>Available roles:</div>
@@ -116,6 +203,7 @@ const Roles = () => {
                     ))}
                 </>
             )}
+            {formPermissionsList}
         </div>
     );
 };


### PR DESCRIPTION
[What?]
Adding an option to select permissions, when adding a new role.

[Why?]
A role without permissions does not have any purpose.

[How?]
Getting permission list from the backend and rendering it when the `add new role` form is rendered.
The variable is `formPermissionsList`, which is a list of permissions - added and removed depending on checking and unchecking the checkbox for permission.

[Testing?]
- test if all roles are rendered with the `add new role` form

[Anything_else?]