### PR TITLE
Adding groups to backend response for `get_profiles`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-    "cSpell.words": ["Signout", "signup", "skillup", "Topbar", "vzdrževanja"]
+    "cSpell.words": [
+        "shopprofile",
+        "Signout",
+        "signup",
+        "skillup",
+        "Topbar",
+        "vzdrževanja"
+    ]
 }

--- a/backend/shop/serializers.py
+++ b/backend/shop/serializers.py
@@ -30,6 +30,16 @@ class ShopProfileSerializer(ModelSerializer):
         return f"{obj.first_name} {obj.last_name}"
 
 
+class ShopProfileSerializerPlusGroups(ShopProfileSerializer):
+    groups = SerializerMethodField()
+
+    class Meta(ShopProfileSerializer.Meta):
+        fields = ShopProfileSerializer.Meta.fields + ["groups"]
+
+    def get_groups(self, obj):
+        return [group.name for group in obj.user.groups.all()]
+
+
 class PermissionSerializer(ModelSerializer):
     class Meta:
         model = Permission

--- a/backend/shop/serializers.py
+++ b/backend/shop/serializers.py
@@ -10,8 +10,9 @@ from shop.models import ShopProfile
 
 class ShopProfileSerializer(ModelSerializer):
     email = EmailField(source="user.email")
-    full_name = SerializerMethodField()
+    full_name = SerializerMethodField(read_only=True)
     username = CharField(source="user.username")
+    groups = SerializerMethodField(read_only=True)
 
     class Meta:
         model = ShopProfile
@@ -23,18 +24,12 @@ class ShopProfileSerializer(ModelSerializer):
             "last_name",
             "username",
             "avatar",
+            "groups",
             # 'actions',
         ]
 
     def get_full_name(self, obj):
         return f"{obj.first_name} {obj.last_name}"
-
-
-class ShopProfileSerializerPlusGroups(ShopProfileSerializer):
-    groups = SerializerMethodField()
-
-    class Meta(ShopProfileSerializer.Meta):
-        fields = ShopProfileSerializer.Meta.fields + ["groups"]
 
     def get_groups(self, obj):
         return [group.name for group in obj.user.groups.all()]

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -14,12 +14,7 @@ from rest_framework.response import Response
 from shop.models import ShopProfile
 
 from .permissions import can_view_groups
-from .serializers import (
-    GroupSerializer,
-    PermissionSerializer,
-    ShopProfileSerializer,
-    ShopProfileSerializerPlusGroups,
-)
+from .serializers import GroupSerializer, PermissionSerializer, ShopProfileSerializer
 
 
 @api_view(["GET"])
@@ -88,7 +83,7 @@ def get_profiles(request):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
-    serializer = ShopProfileSerializerPlusGroups(page.object_list, many=True)
+    serializer = ShopProfileSerializer(page.object_list, many=True)
     serialized_rows = serializer.data
 
     pagination_description = {


### PR DESCRIPTION
[What?]
Adding groups to backend response for `get_profiles`.

[Why?]
Those groups can be shown on the frontend table of users.

[How?]
UPDATE: I add the field 'groups' to the existing serializer.

[Testing?]
- test, if not authenticated user has restricted access
- test if groups are in response