### PR TITLE
adding endpoint for products

### DIFF
--- a/backend/shop/permissions.py
+++ b/backend/shop/permissions.py
@@ -4,3 +4,11 @@ def can_view_groups(user):
         or user.has_perm("auth.change_group")
         or user.has_perm("auth.view_group")
     )
+
+
+def can_view_products(user):
+    return (
+        user.is_superuser
+        or user.has_perm("shop.change_product")
+        or user.has_perm("shop.view_product")
+    )

--- a/backend/shop/serializers.py
+++ b/backend/shop/serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import (
     ModelSerializer,
     SerializerMethodField,
 )
-from shop.models import ShopProfile
+from shop.models import Product, ShopProfile
 
 
 class ShopProfileSerializer(ModelSerializer):
@@ -45,3 +45,9 @@ class GroupSerializer(ModelSerializer):
     class Meta:
         model = Group
         fields = ["id", "name"]
+
+
+class ProductSerializer(ModelSerializer):
+    class Meta:
+        model = Product
+        fields = "__all__"

--- a/backend/shop/serializers.py
+++ b/backend/shop/serializers.py
@@ -50,4 +50,4 @@ class GroupSerializer(ModelSerializer):
 class ProductSerializer(ModelSerializer):
     class Meta:
         model = Product
-        fields = "__all__"
+        fields = ["id", "image", "title", "description", "price"]

--- a/backend/shop/tests/test_views.py
+++ b/backend/shop/tests/test_views.py
@@ -498,11 +498,11 @@ class TestProductGet(APITestCase):
 
         self.user_product_viewer = CoreUserFactory()
         perm_view_product = Permission.objects.get(codename="view_product")
-        self.user_viewer.user_permissions.add(perm_view_product)
+        self.user_product_viewer.user_permissions.add(perm_view_product)
 
         self.user_product_editor = CoreUserFactory()
         perm_change_product = Permission.objects.get(codename="change_product")
-        self.user.user_permissions.add(perm_change_product)
+        self.user_product_editor.user_permissions.add(perm_change_product)
 
         self.url_all = reverse("product_get_all")
 
@@ -550,11 +550,11 @@ class TestProductCreate(APITestCase):
 
         self.user_product_viewer = CoreUserFactory()
         perm_view_product = Permission.objects.get(codename="view_product")
-        self.user_viewer.user_permissions.add(perm_view_product)
+        self.user_product_viewer.user_permissions.add(perm_view_product)
 
         self.user_product_editor = CoreUserFactory()
         perm_change_product = Permission.objects.get(codename="change_product")
-        self.user.user_permissions.add(perm_change_product)
+        self.user_product_editor.user_permissions.add(perm_change_product)
 
         self.url = reverse("product_create")
 

--- a/backend/shop/urls.py
+++ b/backend/shop/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
-
-from . import views
+from shop import views
 
 urlpatterns = [
     # prefix "shop-api-v1/"
@@ -8,7 +7,10 @@ urlpatterns = [
     path("profile/new", views.profile_create, name="profile_create"),
     path("profile/<str:profile_id>/", views.profile, name="profile"),
     path("role/", views.role_get, name="role_get"),
-    path("permission/", views.permission_get, name="permission_get"),
     path("role/new/", views.role_create, name="role_create"),
+    path("permission/", views.permission_get, name="permission_get"),
     path("permission-user/", views.permission_user_get, name="permission_user"),
+    path("product/", views.product_get, name="product_get_all"),
+    path("product/<int:product_id>/", views.product_get, name="product_get"),
+    path("product/create/", views.product_create, name="product_create"),
 ]


### PR DESCRIPTION
[What?]
Add API endpoints for manipulating `products`.

[Why?]
The frontend user can `get` and `put` data.

[How?]
- creating URLs (get_products, get_products_all, put_products)
- add serializer for `product` model
- add views for `get_product_get` (get one  and get all) and `put_product_create`
- new test_permission function `can_view_product`

[Testing?]
- product_get_all (authenticated, not authenticated, with permission, without permission, wrong permission)
- product_get_one
- product_put

[Anything_else?]
1. Please pay attention to `TestProductCreate.setUp`. Is this the right way to test uploading an image?
2. Is this PR too big?