### PR TITLE
Editing db order from frontend

### DIFF
--- a/backend/shop/urls.py
+++ b/backend/shop/urls.py
@@ -4,6 +4,7 @@ from shop import views
 
 router = DefaultRouter()
 router.register(r"order", views.OrderViewSet, basename="order")
+router.register(r"order-item", views.OrderItemViewSet, basename="order-item")
 
 urlpatterns = [
     # prefix "shop-api-v1/"

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -9,7 +9,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from shop.models import Order, Product, ShopProfile
+from shop.models import Order, Product, ShopProfile, OrderItem
 from shop.permissions import CanModifyOrViewOrder, can_view_groups, can_view_products
 from shop.serializers import (
     GroupSerializer,
@@ -17,6 +17,7 @@ from shop.serializers import (
     PermissionSerializer,
     ProductSerializer,
     ShopProfileSerializer,
+    OrderItemSerializer,
 )
 from django.core.paginator import EmptyPage
 
@@ -311,3 +312,8 @@ class OrderViewSet(viewsets.ModelViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
     permission_classes = [IsAuthenticated, CanModifyOrViewOrder]
+
+
+class OrderItemViewSet(viewsets.ModelViewSet):
+    queryset = OrderItem.objects.all()
+    serializer_class = OrderItemSerializer

--- a/frontend/src/pages/dashboard/orders/Orders.tsx
+++ b/frontend/src/pages/dashboard/orders/Orders.tsx
@@ -51,25 +51,41 @@ const Orders = () => {
         }
     };
 
-    const handleQuantityChange = (
+    const handleQuantityChange = async (
         orderId: number,
         orderItemId: number,
         newQuantity: number,
     ) => {
-        setOrders((prevOrders) =>
-            prevOrders.map((order) =>
-                order.id === orderId
-                    ? {
-                          ...order,
-                          order_items: order.order_items.map((orderItem) =>
-                              orderItem.id === orderItemId
-                                  ? { ...orderItem, quantity: newQuantity }
-                                  : orderItem,
-                          ),
-                      }
-                    : order,
-            ),
-        );
+        try {
+            const response = await api.patch(
+                `/shop-api-v1/order-item/${orderItemId}/`,
+                { quantity: newQuantity },
+            );
+            if (response.status === 200) {
+                setOrders((prevOrders) =>
+                    prevOrders.map((order) =>
+                        order.id === orderId
+                            ? {
+                                  ...order,
+                                  order_items: order.order_items.map(
+                                      (orderItem) =>
+                                          orderItem.id === orderItemId
+                                              ? {
+                                                    ...orderItem,
+                                                    quantity: newQuantity,
+                                                }
+                                              : orderItem,
+                                  ),
+                              }
+                            : order,
+                    ),
+                );
+            } else {
+                console.error(`Failed to update order item ${orderItemId}.`);
+            }
+        } catch (err) {
+            console.error(`Error updating order item ${orderItemId}:`, err);
+        }
     };
 
     const handleRemoveItem = async (orderId: number, orderItemId: number) => {


### PR DESCRIPTION
[What?]
When a product quantity is edited (or product removed) in the frontend, the related item in the backend is updated.
If all products from one order are removed, the order is deleted as well.

[Why?]
The data in the backend must be synchronized with frontend data.

[How?]
- adding `order-item` endpoint
- adding `OrderItemViewSet` view class
- when a changed product quantity is requested, the backend endpoint is called for changing DB quantity, if it is successful, delete in fronted as well:
```
        api.patch(
            `/shop-api-v1/order-item/${orderItemId}/`,
            { quantity: newQuantity },
        );
```
- If product removal is requested, the backend endpoint for deleting is called, if it is successful, delete in fronted as well:
    ```
        api.delete(
            `/shop-api-v1/order-item/${orderItemId}`,
        );
    ```

[Testing?]
Future PR: created GitHub issue.

[Anything_else?]
The API endpoint is not protected.
Need to add `permission_classes`.